### PR TITLE
replacing `.unwrap()` with `?` in rust files

### DIFF
--- a/2022/day4/day4rust/src/main.rs
+++ b/2022/day4/day4rust/src/main.rs
@@ -39,7 +39,7 @@ fn parse_input_file(filename: &String) -> Result<Vec<(i32, i32, i32, i32)>> {
     // half of that as an i32. Then, push those i32s into a vector
     for row in rdr.records() {
         let mut extension = Vec::new();
-        for item in row.unwrap().into_iter() { // I know `.unwrap()` is unsafe; I don't care
+        for item in row?.into_iter() {
             for tm in item.split("-").into_iter() {
                 extension.push(tm.parse::<i32>()?);
             }

--- a/2022/day5/day5rust/src/main.rs
+++ b/2022/day5/day5rust/src/main.rs
@@ -14,7 +14,7 @@ const INSTR_FILE_IDX: usize = 2;
 
 struct Config {
     state_filename: String,
-    instr_filename: String, 
+    instr_filename: String,
 }
 
 impl Config {
@@ -65,7 +65,7 @@ fn fill_stacks_map(state_filename: &String) -> Result<BTreeMap<String, Vec<Strin
     );
 
     for line in reader.lines() {
-        let (crate_number, crates) = parse_state_line(line.unwrap());
+        let (crate_number, crates) = parse_state_line(line?);
 
         if !stacks_map.contains_key(&crate_number) {
             stacks_map.insert(crate_number.clone(), Vec::new());

--- a/2022/day6/day6rust/src/main.rs
+++ b/2022/day6/day6rust/src/main.rs
@@ -35,7 +35,7 @@ fn solver(input_file: &String, pointer2start: usize) -> Result<usize> {
 
     // This for loop only runs once since each file only has one line in it
     for line in reader.lines() {
-        let ln = line.unwrap();
+        let ln = line?;
         while pointer2 < ln.len() {
             let pointed_chars = &ln[pointer1..pointer2];
             let charset: HashSet<char> = pointed_chars.chars().collect();


### PR DESCRIPTION
I had been doing
```rust
// stuff above here
for line in reader.lines() {
  let ln = line.unwrap();
  // more stuff here
}
```
which is bad since `.unwrap()` can fail and panics if so vs handling the error with a match statement.

Since my code already handles errors, I changed the rust to read
```rust
// stuff above here
for line in reader.lines() {
  let ln = line?;
  // more stuff here
}
```
so that the error isn't swallowed and is reported properly.
